### PR TITLE
Basic認証追加（本番環境でのみ起動）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,16 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth, if: :production?
+  protect_from_forgery with: :exception
+
+  private
+
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -60,3 +60,5 @@
 #     # password: "please use keys"
 #   }
 server '18.178.95.21', user: 'ec2-user', roles: %w{app db web}
+set :rails_env, "production"
+set :unicorn_rack_env, "production"


### PR DESCRIPTION
#What
必要最低限の認証機能を作成中のWebアプリケーションに実装したい

#Why
サーバーと通信する時にユーザー名とパスワードを知っている人じゃないと、そのサイトにアクセス出来ないようにする。（アプリは商業用ではなく、課題として作成しているため）
