### PR TITLE
記述修正

### DIFF
--- a/app/views/shared/_pickup_category.html.haml
+++ b/app/views/shared/_pickup_category.html.haml
@@ -80,7 +80,7 @@
       = link_to '#' do
         %h3.title テスト
     .productLists
-      - if @products_ladies.empty?
+      - if @products_test.empty?
         .productLists__not
           現在商品はありません。
       - else


### PR DESCRIPTION
＃What
Topページの条件分岐に誤りがあったため修正
#Why
本来ならブランドの「テスト」を選択して商品を出品するとTopページに表示されますが、
表示されていなかった。
条件分岐がブランドの「テスト」ではなく、カテゴリの「レディース」となっていたため修正します。